### PR TITLE
Adding table for invoice

### DIFF
--- a/app.R
+++ b/app.R
@@ -276,7 +276,7 @@ server <- function(input, output, session) {
                         Quantity=numeric(0), Amount=numeric(0), Total=numeric(0)))
     }
     tryCatch(
-      generateInvoiceTable(dat2),
+      new_table <- generateInvoiceTable(dat2),
       error = function(e) {
         showNotification(paste("Failed to build invoice table:", e$message),
                          type = "error", duration = NULL)
@@ -284,7 +284,12 @@ server <- function(input, output, session) {
                    Quantity=numeric(0), Amount=numeric(0), Total=numeric(0))
       }
     )
+    
+    output$editable_invoice_table <- DT::renderDataTable({
+      new_table
+    })
   })
+
   
   generateQuoteID <- function() {
     date_part <- format(Sys.Date(), "%Y%m%d")


### PR DESCRIPTION
This fixes the problem of the table not being shown after selecting two rows and clicking create invoice.

Test:

1. Upload spreadsheet
2. Filter using kbrand
3. Select 2 out of the 5 rows available
4. Click on Create Invoice
5. In the invoice table there should be 2 rows that you selected.